### PR TITLE
スモークの効きを強化

### DIFF
--- a/src/main/kotlin/net/yukulab/robandpeace/item/SmokeItem.kt
+++ b/src/main/kotlin/net/yukulab/robandpeace/item/SmokeItem.kt
@@ -2,6 +2,7 @@ package net.yukulab.robandpeace.item
 
 import net.minecraft.entity.effect.StatusEffectInstance
 import net.minecraft.entity.effect.StatusEffects
+import net.minecraft.entity.mob.Angerable
 import net.minecraft.entity.mob.MobEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.Item
@@ -47,9 +48,10 @@ class SmokeItem : Item(Settings()) {
             val duration = stack.getOrDefault(RapComponents.SMOKE_INVISIBLE_DURATION, RapConfigs.serverConfig.items.smokeInvisibleDuration)
             user.addStatusEffect(StatusEffectInstance(StatusEffects.INVISIBILITY, duration, 0, false, false))
             world.getEntitiesByClass(MobEntity::class.java, user.boundingBox.expand(10.0)) {
-                it.isAlive && it.target == user
+                it.isAlive && it.target == user || (it is Angerable && it.shouldAngerAt(user))
             }.forEach {
                 it.target = null
+                (it as? Angerable)?.stopAnger()
             }
         }
 


### PR DESCRIPTION
AngeraleEntityに対する効きを良くしました。
コミットにも書いた通りこれでもMobによって殴って数秒は効かなかったりします。

> まあ煙幕の効果考えたら動物とか相手にやっても嗅ぎ分けられそうだしこんなもんとする