### PR TITLE
SpiderWalkerがマルチプレイ時に動作しない問題の修正

### DIFF
--- a/src/client/kotlin/net/yukulab/robandpeace/RobPeaceClient.kt
+++ b/src/client/kotlin/net/yukulab/robandpeace/RobPeaceClient.kt
@@ -1,12 +1,17 @@
 package net.yukulab.robandpeace
 
 import net.fabricmc.api.ClientModInitializer
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking
 import net.yukulab.robandpeace.entity.RapEntityRenderers
 import net.yukulab.robandpeace.item.RapItemModelProvider
+import net.yukulab.robandpeace.network.payload.PlayerMovementPayload
 
 object RobPeaceClient : ClientModInitializer {
     override fun onInitializeClient() {
         RapEntityRenderers.init()
         RapItemModelProvider.registerModelPredicateProviders()
+        ClientPlayNetworking.registerGlobalReceiver(PlayerMovementPayload.ID) { payload, context ->
+            RobAndPeace.playerMovementStatusMap[context.player().uuid] = payload
+        }
     }
 }

--- a/src/main/kotlin/net/yukulab/robandpeace/RobAndPeace.kt
+++ b/src/main/kotlin/net/yukulab/robandpeace/RobAndPeace.kt
@@ -1,6 +1,7 @@
 package net.yukulab.robandpeace
 
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +32,7 @@ object RobAndPeace : ModInitializer {
     var isDebugMode: Boolean = false
 
     @JvmField
-    val playerMovementStatusMap = mutableMapOf<UUID, PlayerMovementPayload>()
+    val playerMovementStatusMap = ConcurrentHashMap<UUID, PlayerMovementPayload>()
 
     @JvmStatic
     fun getPlayerMovementStatus(playerUUID: UUID): PlayerMovementPayload = playerMovementStatusMap.getOrDefault(playerUUID, EMPTY_PAYLOAD)

--- a/src/main/kotlin/net/yukulab/robandpeace/network/RabNetworking.kt
+++ b/src/main/kotlin/net/yukulab/robandpeace/network/RabNetworking.kt
@@ -12,9 +12,13 @@ object RabNetworking {
 
     fun init() {
         PayloadTypeRegistry.playC2S().register(PlayerMovementPayload.ID, PlayerMovementPayload.CODEC)
+        PayloadTypeRegistry.playS2C().register(PlayerMovementPayload.ID, PlayerMovementPayload.CODEC)
 
         ServerPlayNetworking.registerGlobalReceiver(PlayerMovementPayload.ID) { payload, context ->
             RobAndPeace.playerMovementStatusMap[context.player().uuid] = payload
+            context.server().playerManager.playerList.forEach {
+                ServerPlayNetworking.send(it, payload)
+            }
         }
     }
 }


### PR DESCRIPTION
同期を取る際にローカル動作ではplayerMovementStatusMapがサーバーのNettyとローカルのNettyの2つのスレッドから編集されてしまうためConcurrentModificationException対策でConcurrentHashMapに変更しています